### PR TITLE
Fix C4-691 and C4-692 regarding information passing into foursight-core building operations

### DIFF
--- a/.github/workflows/main-CI.yml
+++ b/.github/workflows/main-CI.yml
@@ -1,4 +1,4 @@
-# CI for Foursight-coret
+# CI for Foursight-core
 
 name: CI
 
@@ -40,4 +40,4 @@ jobs:
         env:
           S3_ENCRYPT_KEY: ${{ secrets.S3_ENCRYPT_KEY }}
           DEV_SECRET: ${{ secrets.DEV_SECRET }}
-        run: poetry run pytest -vv tests -m "not integratedx"
+        run: make automated-test

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,39 @@
+==============
+foursight-core
+==============
+
+----------
+Change Log
+----------
+
+
+0.4.0
+=====
+
+Compatible/transitional support for:
+
+* Fix for `foursight-core Deploy.build_config_and_package should take global_env_bucket as an argument (C4-691)
+  <https://hms-dbmi.atlassian.net/browse/C4-691>`_: Allow environment variable (either one,
+  checking for consistency if both are set) or an argument.
+  If the argument is passed, it takes precedence even if not consistent with environment variables.
+
+* Fix for `foursight-core Deploy.build_config_and_package should not need an 'args' arg
+  <https://hms-dbmi.atlassian.net/browse/C4-692>`_: Allow any of four new named arguments to override
+  the various parts of ``args`` that might get used. So passing ``merge_template=`` causes that value to be
+  used in lieu of ``args.merge_template``, and ``output_file=`` gets used in lieu of ``args.output_file``,
+  and ``stage=`` gets used instead of ``args.stage``, and ``trial=`` gets used in place of ``args.trial``.
+
+
+Older Versions
+==============
+
+A record of older changes can be found
+`in GitHub <https://github.com/4dn-dcic/foursight-core/pulls?q=is%3Apr+is%3Aclosed>`_.
+To find the specific version numbers, see the ``version`` value in
+the ``poetry.app`` section of ``pyproject.toml``, as in::
+
+   [poetry.app]
+   name = "foursight-core"
+   version = "100.200.300"
+   ...etc.
+

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,10 @@ update:
 	poetry update
 
 test:
-	pytest -vv --cov foursight_core tests
+	pytest -vv --cov foursight_core
+
+automated-test:
+	poetry run pytest --cov foursight_core -vv -m "not integratedx"
 
 info:
 	@: $(info Here are some 'make' options:)

--- a/foursight_core/deploy.py
+++ b/foursight_core/deploy.py
@@ -3,16 +3,17 @@ Generate gitignored .chalice/config.json for deploy and then run deploy.
 Takes on parameter for now: stage (either "dev" or "prod")
 """
 import os
-from os.path import dirname
 import sys
 import argparse
 import json
 import subprocess
 
+from dcicutils.misc_utils import as_seconds
+
 
 class Deploy(object):
 
-    DEFAULT_LAMBDA_TIMEOUT = 60 * 15  # 900 seconds = 15 minutes
+    DEFAULT_LAMBDA_TIMEOUT = as_seconds(minutes=15)
 
     CONFIG_BASE = {
       "stages": {
@@ -42,7 +43,7 @@ class Deploy(object):
       ]
     }
 
-    config_dir = dirname(__file__)
+    config_dir = os.path.dirname(__file__)
 
     @classmethod
     def get_config_filepath(cls):

--- a/foursight_core/deploy.py
+++ b/foursight_core/deploy.py
@@ -12,13 +12,15 @@ import subprocess
 
 class Deploy(object):
 
+    DEFAULT_LAMBDA_TIMEOUT = 60 * 15  # 900 seconds = 15 minutes
+
     CONFIG_BASE = {
       "stages": {
         "dev": {
           "api_gateway_stage": "api",
           "autogen_policy": False,
           "lambda_memory_size": 512,
-          "lambda_timeout": 900,  # 15 mins in seconds
+          "lambda_timeout": DEFAULT_LAMBDA_TIMEOUT,  # 15 mins in seconds
           "environment_variables": {
               "chalice_stage": "dev"
           }
@@ -27,7 +29,7 @@ class Deploy(object):
           "api_gateway_stage": "api",
           "autogen_policy": False,
           "lambda_memory_size": 512,
-          "lambda_timeout": 900,  # 15 mins in seconds
+          "lambda_timeout": DEFAULT_LAMBDA_TIMEOUT,  # 15 mins in seconds
           "environment_variables": {
               "chalice_stage": "prod"
           }
@@ -48,7 +50,8 @@ class Deploy(object):
 
     @classmethod
     def build_config(cls, stage, trial_creds=None, trial_global_env_bucket=False, global_env_bucket=None,
-                     security_group_ids=None, subnet_ids=None, check_runner=None, lambda_timeout=60):
+                     security_group_ids=None, subnet_ids=None, check_runner=None,
+                     lambda_timeout=DEFAULT_LAMBDA_TIMEOUT):
         """ Builds the chalice config json file. See: https://aws.github.io/chalice/topics/configfile"""
         if trial_creds:
             # key to decrypt access key
@@ -131,7 +134,8 @@ class Deploy(object):
 
     @classmethod
     def build_config_and_package(cls, args, trial_creds=None, global_env_bucket=None,
-                                 security_ids=None, subnet_ids=None, check_runner=None, lambda_timeout=60,
+                                 security_ids=None, subnet_ids=None, check_runner=None,
+                                 lambda_timeout=DEFAULT_LAMBDA_TIMEOUT,
                                  # These next args are preferred over passing 'args'.
                                  merge_template=None, output_file=None, stage=None, trial=None,
                                  ):

--- a/foursight_core/deploy.py
+++ b/foursight_core/deploy.py
@@ -48,7 +48,7 @@ class Deploy(object):
 
     @classmethod
     def build_config(cls, stage, trial_creds=None, trial_global_env_bucket=False, global_env_bucket=None,
-                     security_group_ids=None, subnet_ids=None, check_runner=None):
+                     security_group_ids=None, subnet_ids=None, check_runner=None, lambda_timeout=60):
         """ Builds the chalice config json file. See: https://aws.github.io/chalice/topics/configfile"""
         if trial_creds:
             # key to decrypt access key
@@ -91,7 +91,7 @@ class Deploy(object):
                 curr_stage_environ['ES_HOST'] = es_host
             if trial_global_env_bucket:
                 # in the trial account setup, use a shorter timeout
-                curr_stage['lambda_timeout'] = 60
+                curr_stage['lambda_timeout'] = lambda_timeout
                 if not global_env_bucket:
                     global_bucket_env_from_environ = os.environ.get('GLOBAL_BUCKET_ENV')
                     global_env_bucket_from_environ = os.environ.get('GLOBAL_ENV_BUCKET')
@@ -131,7 +131,7 @@ class Deploy(object):
 
     @classmethod
     def build_config_and_package(cls, args, trial_creds=None, global_env_bucket=None,
-                                 security_ids=None, subnet_ids=None, check_runner=None,
+                                 security_ids=None, subnet_ids=None, check_runner=None, lambda_timeout=60,
                                  # These next args are preferred over passing 'args'.
                                  merge_template=None, output_file=None, stage=None, trial=None,
                                  ):
@@ -152,7 +152,7 @@ class Deploy(object):
         if trial:
             if trial_creds and security_ids and subnet_ids and check_runner:
                 cls.build_config(stage, trial_creds=trial_creds, trial_global_env_bucket=True,
-                                 global_env_bucket=global_env_bucket,
+                                 global_env_bucket=global_env_bucket, lambda_timeout=lambda_timeout,
                                  security_group_ids=security_ids, subnet_ids=subnet_ids, check_runner=check_runner)
             else:
                 raise Exception('Build config requires trial_creds, sg id, and subnet ids to run in trial account')

--- a/foursight_core/deploy.py
+++ b/foursight_core/deploy.py
@@ -47,7 +47,7 @@ class Deploy(object):
         return os.path.join(cls.config_dir, '.chalice/config.json')
 
     @classmethod
-    def build_config(cls, stage, trial_creds=None, trial_global_env_bucket=False,
+    def build_config(cls, stage, trial_creds=None, trial_global_env_bucket=False, global_env_bucket=None,
                      security_group_ids=None, subnet_ids=None, check_runner=None):
         """ Builds the chalice config json file. See: https://aws.github.io/chalice/topics/configfile"""
         if trial_creds:
@@ -77,30 +77,43 @@ class Deploy(object):
                                'Need: S3_ENCRYPT_KEY, CLIENT_ID, CLIENT_SECRET, DEV_SECRET.'])
                       )
                 sys.exit()
-        for curr_stage in ['dev', 'prod']:
-            cls.CONFIG_BASE['stages'][curr_stage]['environment_variables']['S3_ENCRYPT_KEY'] = s3_enc_secret
-            cls.CONFIG_BASE['stages'][curr_stage]['environment_variables']['CLIENT_ID'] = client_id
-            cls.CONFIG_BASE['stages'][curr_stage]['environment_variables']['CLIENT_SECRET'] = client_secret
-            cls.CONFIG_BASE['stages'][curr_stage]['environment_variables']['DEV_SECRET'] = dev_secret
+        for curr_stage_name in ['dev', 'prod']:
+            curr_stage = cls.CONFIG_BASE['stages'][curr_stage_name]
+            curr_stage_environ = curr_stage['environment_variables']
+
+            curr_stage_environ['S3_ENCRYPT_KEY'] = s3_enc_secret
+            curr_stage_environ['CLIENT_ID'] = client_id
+            curr_stage_environ['CLIENT_SECRET'] = client_secret
+            curr_stage_environ['DEV_SECRET'] = dev_secret
             if env_name:
-                cls.CONFIG_BASE['stages'][curr_stage]['environment_variables']['ENV_NAME'] = env_name
+                curr_stage_environ['ENV_NAME'] = env_name
             if es_host:
-                cls.CONFIG_BASE['stages'][curr_stage]['environment_variables']['ES_HOST'] = es_host
+                curr_stage_environ['ES_HOST'] = es_host
             if trial_global_env_bucket:
                 # in the trial account setup, use a shorter timeout
-                cls.CONFIG_BASE['stages'][curr_stage]['lambda_timeout'] = 60
-                global_bucket = os.environ.get('GLOBAL_BUCKET_ENV')
-                if global_bucket:
-                    cls.CONFIG_BASE['stages'][curr_stage]['environment_variables']['GLOBAL_BUCKET_ENV'] = global_bucket
+                curr_stage['lambda_timeout'] = 60
+                if not global_env_bucket:
+                    global_bucket_env_from_environ = os.environ.get('GLOBAL_BUCKET_ENV')
+                    global_env_bucket_from_environ = os.environ.get('GLOBAL_ENV_BUCKET')
+                    if (global_bucket_env_from_environ
+                            and global_env_bucket_from_environ
+                            and global_bucket_env_from_environ != global_env_bucket_from_environ):
+                        print('ERROR. GLOBAL_BUCKET_ENV and GLOBAL_ENV_BUCKET are both set, but inconsistently.')
+                        sys.exit()
+                    global_env_bucket = global_bucket_env_from_environ or global_env_bucket_from_environ
+                if global_env_bucket:
+                    curr_stage_environ['GLOBAL_BUCKET_ENV'] = global_env_bucket  # legacy compatibility
+                    curr_stage_environ['GLOBAL_ENV_BUCKET'] = global_env_bucket
                 else:
-                    print('ERROR. GLOBAL_BUCKET_ENV must be set when building the trial config.')
+                    print('ERROR. GLOBAL_ENV_BUCKET must be set or global_env_bucket= must be passed'
+                          ' when building the trial config.')
                     sys.exit()
             if security_group_ids:
-                cls.CONFIG_BASE['stages'][curr_stage]['security_group_ids'] = security_group_ids
+                curr_stage['security_group_ids'] = security_group_ids
             if subnet_ids:
-                cls.CONFIG_BASE['stages'][curr_stage]['subnet_ids'] = subnet_ids
+                curr_stage['subnet_ids'] = subnet_ids
             if check_runner:
-                cls.CONFIG_BASE['stages'][curr_stage]['environment_variables']['CHECK_RUNNER'] = check_runner
+                curr_stage_environ['CHECK_RUNNER'] = check_runner
 
         filename = cls.get_config_filepath()
         print(''.join(['Writing: ', filename]))
@@ -117,24 +130,40 @@ class Deploy(object):
         subprocess.call(['chalice', 'deploy', '--stage', stage])
 
     @classmethod
-    def build_config_and_package(cls, args, trial_creds=None, security_ids=None, subnet_ids=None, check_runner=None):
+    def build_config_and_package(cls, args, trial_creds=None, global_env_bucket=None,
+                                 security_ids=None, subnet_ids=None, check_runner=None,
+                                 # These next args are preferred over passing 'args'.
+                                 merge_template=None, output_file=None, stage=None, trial=None,
+                                 ):
         """ Builds a config with a special case for the trial account. For the trial account, expects a dictionary of
             environment variables, a list of security group ids, and a list of subnet ids. Finally, packages as a
             Cloudformation template."""
-        if args.trial:
+
+        # For compatibility during transition, we allow these argument to be passed in lieu of args.
+        if merge_template is None:
+            merge_template = args.merge_template
+        if output_file is None:
+            output_file = args.output_file
+        if stage is None:
+            stage = args.stage
+        if trial is None:
+            trial = args.trial
+
+        if trial:
             if trial_creds and security_ids and subnet_ids and check_runner:
-                cls.build_config(args.stage, trial_creds=trial_creds, trial_global_env_bucket=True,
+                cls.build_config(stage, trial_creds=trial_creds, trial_global_env_bucket=True,
+                                 global_env_bucket=global_env_bucket,
                                  security_group_ids=security_ids, subnet_ids=subnet_ids, check_runner=check_runner)
             else:
                 raise Exception('Build config requires trial_creds, sg id, and subnet ids to run in trial account')
         else:
-            cls.build_config(args.stage)
+            cls.build_config(stage=stage)
         # actually package cloudformation templates
         # add --single-file ?
-        flags = ['--stage', args.stage, '--pkg-format', 'cloudformation', '--template-format', 'yaml']
-        if args.merge_template:
-            flags.extend(['--merge-template', args.merge_template])
-        subprocess.call(['chalice', 'package', *flags, args.output_file])
+        flags = ['--stage', stage, '--pkg-format', 'cloudformation', '--template-format', 'yaml']
+        if merge_template:
+            flags.extend(['--merge-template', merge_template])
+        subprocess.call(['chalice', 'package', *flags, output_file])
 
 
 def main():
@@ -145,7 +174,7 @@ def main():
         choices=['dev', 'prod'],
         help="chalice deployment stage. Must be one of 'prod' or 'dev'")
     args = parser.parse_args()
-    Deploy.build_config_and_deploy(args.stage)
+    Deploy.build_config_and_deploy(stage=args.stage)
 
 
 if __name__ == '__main__':

--- a/poetry.lock
+++ b/poetry.lock
@@ -175,7 +175,7 @@ toml = ["toml"]
 
 [[package]]
 name = "dcicutils"
-version = "1.19.0"
+version = "1.20.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 category = "main"
 optional = false
@@ -893,7 +893,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6,<3.7"
-content-hash = "6e71d84a3a19d4e21fdecee7d190b92d610fa2b71f8a032de164db76cac4422a"
+content-hash = "e9093fc0a7ec2b7a6bbe8709867e82c1b5c04b1315cfb736f90bf6a5318fda51"
 
 [metadata.files]
 ansicon = [
@@ -1008,8 +1008,8 @@ coverage = [
     {file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c"},
 ]
 dcicutils = [
-    {file = "dcicutils-1.19.0-py3-none-any.whl", hash = "sha256:af6e2b13ea92857140fe98a18a06bfe41e7fdd1c4c065e0f74368aed5b2983c4"},
-    {file = "dcicutils-1.19.0.tar.gz", hash = "sha256:883bbaa442a6c410fe1278cc39d2b0b0d808be2e14cb55e9adc1751e3bd232f1"},
+    {file = "dcicutils-1.20.0-py3-none-any.whl", hash = "sha256:4330e56d1ca534ee4b3956213e821e17615df12ea36b48f02df85696fd06a028"},
+    {file = "dcicutils-1.20.0.tar.gz", hash = "sha256:22cb34628845afa2f9a13e341958dc9e4789351f1935e2f323203416d4abfca0"},
 ]
 decorator = [
     {file = "decorator-5.0.9-py3-none-any.whl", hash = "sha256:6e5c199c16f7a9f0e3a61a4a54b3d27e7dad0dbdde92b944426cb20914376323"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight_core"
-version = "0.3.0"
+version = "0.4.0"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.6,<3.7"
-dcicutils = "^1.7.0"
+dcicutils = "^1.20.0"
 click = "^7.1.2"
 PyJWT = "1.5.3"
 Jinja2 = "2.10.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight_core"
-version = "0.4.0"
+version = "0.2.0.1b0"  # to be merged as 0.3.0 eventually
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+norecursedirs = *env site-packages .cache .git .idea *.egg-info
+testpaths =
+    tests
+markers =
+  integrated: an integration test
+  integratedx: an excludable integration test, redundantly testing functionality also covered by a unit test
+  unit: a proper unit test

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,0 +1,7 @@
+from foursight_core.deploy import Deploy
+
+
+# TODO: This is just one ceremonial test, an invitation to write some real tests.
+def test_deploy_default_lambda_timeout():
+
+    assert Deploy.DEFAULT_LAMBDA_TIMEOUT == 60 * 15  # 15 minutes

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -1,12 +1,20 @@
 import os
+
+from dcicutils.misc_utils import override_environ
 from foursight_core import stage
 
 
-class TestStage():
+class TestStage:
+
     def test_get_stage_info(self):
-        os.environ['chalice_stage'] = 'test'
-        stage_obj = stage.Stage('placeholder_prefix')
-        assert stage_obj.get_stage() == 'dev'
-        assert stage.Stage.get_stage() == 'dev'  # this one is also a classmethod
-        assert 'dev' in stage_obj.get_runner_name()
-        assert 'test' in stage_obj.get_queue_name()
+
+        # Testing assumes CHECK_RUNNER env var is not set and gets a default, since a developer
+        # might have it set in their debugging environment in a way that thwartsthe test.
+        with override_environ(CHECK_RUNNER=None):
+
+            os.environ['chalice_stage'] = 'test'
+            stage_obj = stage.Stage('placeholder_prefix')
+            assert stage_obj.get_stage() == 'dev'
+            assert stage.Stage.get_stage() == 'dev'  # this one is also a classmethod
+            assert 'dev' in stage_obj.get_runner_name()
+            assert 'test' in stage_obj.get_queue_name()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,12 @@
+import os
+
+from dcicutils.qa_utils import VersionChecker
+
+
+def test_version_checker_use_dcicutils_changelog():
+
+    class MyVersionChecker(VersionChecker):
+        PYPROJECT = os.path.join(os.path.dirname(__file__), "../pyproject.toml")
+        CHANGELOG = os.path.join(os.path.dirname(__file__), "../CHANGELOG.rst")
+
+    MyVersionChecker.check_version()


### PR DESCRIPTION
This does two main things to fix [C4-691](https://hms-dbmi.atlassian.net/browse/C4-691) and [C4-692](https://hms-dbmi.atlassian.net/browse/C4-692), both really in `foursight-cores`'s `Deploy.build_config_and_package` (in `deploy.py`).

* It makes it possible to pass the global_env_bucket as a lexical argument during deployment. (In the process, I also make it possible to use either of the variables `GLOBAL_BUCKET_ENV` or `GLOBAL_ENV_BUCKET` during the transition so that we can phase `GLOBAL_BUCKET_ENV` out gracefully. As long as they are set consistently, both can be set. But if `global_bucket_env=` is given, it can override the value, including being different, so that the caller doesn't have to care what the environment is.)

* I also made it possible to use explicit argument names for various values rather than just using `args`, which we should really deprecate as not the right way to pass information. `args` carries additional information that maybe should not be shared with programs and it makes it hard to tell what information is/isn't being used.

In the process, I also did some opportunistic things:

* I added a `CHANGELOG.rst`.

* I added a test that the `CHANGELOG.rst` is kept up-to-date.

* At @willronchetti's suggestion, during code review, in `deploy.py`, make all lambda timeout values be the same value. Use dcicutils.misc_utils.as_seconds for time computation.  

* Fixed `test_stage` unit test to not be affected by binding of `CHECK_RUNNER` environment variable in the environment of the person running the test.

* Changed `.github/workflows/main-CI.yml` use 'make automated-test' instead of a raw call to pytest.

* Define the `automated-test` target in `Makefile` to be what `main-CI.yml` had been doing for testing (so that the nature of testing is controlled in the `Makefile` all in one place instead of being distributed around.).

* Set up `pytest.ini`, including making `tests` (dir) be the default for all `pytest` runs, and make adjustments in the `make` targets to not pass this explicitl.

* Add a trivial test case of `deploy.py` just so that we know we should be writing tests and we have a place to write more tests.