### PR TITLE
Add publishing support

### DIFF
--- a/.github/workflows/main-publish.yml
+++ b/.github/workflows/main-publish.yml
@@ -1,14 +1,14 @@
-# CI for Foursight-core
+# PyPi publish for foursight-core
 
-name: CI
+name: publish 
 
 # Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
+
+  # Publish on all tags
   push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+    tags:
+    - '*'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -25,19 +25,12 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-
-      - name: Build
-        run: make build
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: CI
+          python-version: 3.6
+      - name: Publish
         env:
-          S3_ENCRYPT_KEY: ${{ secrets.S3_ENCRYPT_KEY }}
-          DEV_SECRET: ${{ secrets.DEV_SECRET }}
-        run: make test-for-ga
+          PYPI_USER: ${{ secrets.PYPI_USER }}
+          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: | 
+          make configure
+          make publish-for-ga

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,19 @@ update:
 test:
 	pytest -vv --cov foursight_core
 
-automated-test:
+test-for-ga:
 	poetry run pytest --cov foursight_core -vv -m "not integratedx"
+
+publish:
+	scripts/publish
+
+publish-for-ga:
+	scripts/publish --noconfirm
 
 info:
 	@: $(info Here are some 'make' options:)
 	   $(info - Use 'make configure' to install poetry, though 'make build' will do it automatically.)
 	   $(info - Use 'make build' to install dependencies using poetry.)
 	   $(info - Use 'make test' to run tests with the normal options we use on travis)
+	   $(info - Use 'make publish' to publish this library manually.)
 	   $(info - Use 'make update' to update dependencies)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight_core"
-version = "0.2.0.1b0"  # to be merged as 0.3.0 eventually
+version = "0.2.0.1b1"  # to be merged as 0.3.0 eventually
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+do_confirm=yes
+
+while true; do
+    if [ "$1" = "--help" ]; then
+       echo "Syntax: $0 [ --noconfirm | --help ]*"
+       echo ""
+       echo "Publishes the repository to pypi, after doing various consistency checks."
+       echo ""
+       echo "By default, if all looks good, you will be asked interactively for confirmation."
+       echo "In a script, you may want --noconfirm to suppress this query."
+       exit 1
+    elif [ "$1" = "--noconfirm" ]; then
+       do_confirm=no
+       shift 1
+    elif [ $# -ne 0 ]; then
+       echo "Unexpected argument: $1"
+       exit 1
+    else
+       break
+    fi
+done
+
+if [ -z "$PYPI_USER" ]; then
+    echo '$PYPI_USER is not set.'
+    exit 1
+fi    
+
+if [ -z "$PYPI_PASSWORD" ]; then
+    echo '$PYPI_PASSWORD is not set.'
+    exit 1    
+fi
+
+changes=`git diff`
+
+if [ -n "${changes}" ]; then
+  echo "You have made changes to this branch that you have not committed."
+  exit 1
+fi
+
+staged_changes=`git diff --staged`
+
+if [ -n "${staged_changes}" ]; then
+  echo "You have staged changes to this branch that you have not committed."
+  exit 1
+fi
+
+tagged=`git log -1 --decorate | head -1 | grep 'tag:'`
+
+if [ -z "$tagged" ]; then
+  # We don't encourage people to tag it unless they have no changes pending.
+  echo "You can only publish a tagged commit."
+  exit 1
+fi
+
+if [ "${do_confirm}" = "yes" ]; then
+  read -p "Are you sure you want to publish $(poetry version) to PyPi? "
+  REPLY=`echo "$REPLY" | tr '[:upper:]' '[:lower:]'`
+  if [ "$REPLY" != 'y' ] && [ "$REPLY" != "yes" ]
+  then
+    echo "Publishing aborted."
+    exit 1
+  fi
+fi
+
+poetry publish --no-interaction --build --username=$PYPI_USER --password=$PYPI_PASSWORD


### PR DESCRIPTION
This does:

* Adds scripts/publish, copied from dcicutils. This is a pretty standard portable script.
* Adds a `publish-for-ga` target in `Makefile`. (For consistency, I renamed `automated-test` target to `test-for-ga` and updated the associated github workflow.)
* Adds a workflow to autopublish.

This needs secrets (`PYPI_USER` and `PYPI_PASSWORD`) added to make it work). We're now using separated credentials and I don't think I have the user/password information that needs to be added. @willronchetti, maybe you do? This should be done by generating an API token if we have not done it. It's not necessary to use full credentials for this, and anyway that would block on 2FA.