### PR TITLE
Mostly PEP8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,35 @@
+[flake8]
+max-line-length = 120
+ignore =
+    # ==============================================================
+    # =========  Default list of things Flake8 would ignore ========
+    # ==============================================================
+    # E121: Continuation line under-indented for hanging indent
+    #       https://www.flake8rules.com/rules/E121.html
+    E121,
+    # E123: Closing bracket does not match indentation of opening bracket's line
+    #       https://www.flake8rules.com/rules/E123.html
+    E123,
+    # E126: Continuation line over-indented for hanging indent
+    #       https://www.flake8rules.com/rules/E126.html
+    E126,
+    # E226: Missing whitespace around arithmetic operator
+    #       https://www.flake8rules.com/rules/E226.html
+    E226,
+    # E24: ??? Hard to find doc on why this undocumented code's in default list
+    # E24,
+    # E704: Multiple statements on one line (def)
+    #       https://www.flake8rules.com/rules/E704.html
+    E704,
+    # W503: Line break occurred before a binary operator
+    #       https://www.flake8rules.com/rules/W503.html
+    W503,
+    # W504: Line break occurred after a binary operator
+    #       https://www.flake8rules.com/rules/W503.html
+    W504,
+    # ==============================================================
+    # =====  Other things we think it shouldn't complain about =====
+    # ==============================================================
+    # F541: f-string is missing placeholders
+    #       https://flake8.pycqa.org/en/latest/user/error-codes.html
+    F541

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,8 +7,84 @@ Change Log
 ----------
 
 
+0.6.1
+=====
+
+* Address many PEP8 problems.
+* Bring CHANGELOG.rst up to date.
+
+
+0.6.0
+=====
+
+**PR #21: Python 3.7 support (C4-765)**
+
+* Adjusts python requirement to permit Python 3.7, but still allow 3.6.1 and above.
+  No known incompatibilities.
+
+0.5.0
+=====
+
+**PR #20: Support Encrypted Buckets**
+
+* Small changes needed for encrypted buckets
+
+
+0.4.5
+=====
+
+(Records are uncertain here.)
+
+
+0.4.4
+=====
+
+**PR #19: Repair delete_results**
+
+* Fix for problem where``delete_results`` had inconsistent return type,
+  causing ``foursight-cgap`` to crash in the scenario where no checks are to be cleaned.
+  With this change, it returns a tuple as the docstring says.
+
+
+0.4.3
+=====
+
+**PR #18: Enable RDS Snapshots (1/3)**
+
+* *Needs update*
+
+
+0.4.2
+=====
+
+**PR #17: Changes to remove variable imports from env_utils (C4-700)**
+
+* *Needs update*
+
+
+0.4.1
+=====
+
+**PR #16: Remove dev_secret**
+
+
+0.4.0
+=====
+
+There was no version 0.4.0.
+
+
 0.3.0
 =====
+
+**PR #15: Update for dcicutils 2.0**
+
+**PR #14: Add publishing support**
+
+**PR #13: Fix C4-691 and C4-692 regarding information passing into foursight-core building operations**
+
+**PR #9: foursight-core: chalice package support C4-554 (1/3)**
+
 
 Compatible/transitional support for:
 
@@ -24,16 +100,85 @@ Compatible/transitional support for:
   and ``stage=`` gets used instead of ``args.stage``, and ``trial=`` gets used in place of ``args.trial``.
 
 
-Older Versions
-==============
+0.2.0
+=====
 
-A record of older changes can be found
-`in GitHub <https://github.com/4dn-dcic/foursight-core/pulls?q=is%3Apr+is%3Aclosed>`_.
-To find the specific version numbers, see the ``version`` value in
-the ``poetry.app`` section of ``pyproject.toml``, as in::
+**PR #12: Repair Auth0**
 
-   [poetry.app]
-   name = "foursight-core"
-   version = "100.200.300"
-   ...etc.
+
+0.1.11
+======
+
+**PR #11: remove fuzzywuzzy dependency**
+
+
+0.1.10
+======
+
+* **Needs more info**
+
+
+0.1.9
+=====
+
+**PR #10: Update buckets.py**
+
+
+0.1.8
+=====
+
+**PR #8: Collect run info**
+
+
+0.1.7
+=====
+
+**PR #6: delete check_runs_without_output function wfr_utils.py**
+
+
+0.1.6:
+======
+
+**PR #7: Fix visibility timeout**
+
+* SQS visibility timeout was set to 5 mins but should be 15 mins to reflect the updated lambda timeout.
+
+
+0.1.5
+=====
+
+There was no version 0.1.5
+
+
+0.1.4
+=====
+
+**PR #5: fix for bug AppUtils object has no attribute get_schedule_names**
+
+
+0.1.3
+=====
+
+**PR #4: Core3**
+
+
+0.1.2
+=====
+
+**PR #3: Add GA Workflows**
+
+
+0.1.1
+=====
+
+**PR #2: Core2**
+
+* minor fixes
+
+
+0.1.0
+=====
+
+**PR #1: Core2**
+
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,8 +10,12 @@ Change Log
 0.6.1
 =====
 
-* Address many PEP8 problems.
-* Bring CHANGELOG.rst up to date.
+**PR #23: Mostly PEP8**
+
+* Address many PEP8 issues.
+* Include ``flake8`` among dev dependencies.
+* Add ``make lint`` to run ``flake8``.
+* Bring ``CHANGELOG.rst`` up to date.
 
 
 0.6.0

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@
 configure:  # does any pre-requisite installs
 	pip install poetry
 
+lint:
+	@echo "Running flake8..."
+	@flake8 foursight_core || echo "'flake8 foursight_core' failed."
+	@flake8 tests || echo "'flake8 tests' failed."
+
 build:  # builds
 	make configure
 	poetry install

--- a/foursight_core/abstract_connection.py
+++ b/foursight_core/abstract_connection.py
@@ -1,3 +1,6 @@
+from dcicutils.misc_utils import ignored
+
+
 class AbstractConnection(object):
     """
     AbstractConnection is an 'abstract' representation of the methods a
@@ -38,10 +41,11 @@ class AbstractConnection(object):
         """
         raise NotImplementedError
 
-    def list_all_keys_w_prefix(self):
+    def list_all_keys_w_prefix(self, prefix):
         """
         Given a prefix, return all keys that have that prefix.
         """
+        ignored(prefix)
         raise NotImplementedError
 
     def get_all_objects(self):

--- a/foursight_core/app_utils.py
+++ b/foursight_core/app_utils.py
@@ -28,7 +28,7 @@ logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 
-class AppUtils(object):
+class AppUtils:
     """
     Class AppUtils is the most high-level class that's used directy by Chalice object app.
     This class mostly contains the functions defined in app_utils in original foursight.
@@ -43,6 +43,8 @@ class AppUtils(object):
 
     # replace with e.g. 'https://search-foursight-fourfront-ylxn33a5qytswm63z52uytgkm4.us-east-1.es.amazonaws.com'
     host = 'placeholder_host'
+
+    OAUTH_TOKEN_URL = "https://hms-dbmi.auth0.com/oauth/token"
 
     # replace with e.g. 'chalicelib'
     package_name = 'foursight_core'
@@ -196,7 +198,7 @@ class AppUtils(object):
         }
         json_payload = json.dumps(payload)
         headers = {'content-type': "application/json"}
-        res = requests.post("https://hms-dbmi.auth0.com/oauth/token", data=json_payload, headers=headers)
+        res = requests.post(cls.OAUTH_TOKEN_URL, data=json_payload, headers=headers)
         id_token = res.json().get('id_token', None)
         if id_token:
             cookie_str = ''.join(['jwtToken=', id_token, '; Domain=', domain, '; Path=/;'])
@@ -1088,7 +1090,9 @@ class AppUtils(object):
                     # action name is the second part of run_name
                     act_name = run_name.split('/')[-1]
                     rec_body = ''.join([act_name, '/', run_uuid, '.json'])
-                    connection.put_object(rec_key, rec_body)
+                    # This was changed per Will's suggestion in code review. -kmp 7-Jun-2022
+                    # connection.put_object(rec_key, rec_body)
+                    connection.connections['s3'].put_object(rec_key, rec_body)
                     print(f'-RUN-> Wrote action record: {rec_key}')
             run_result = self.check_handler.run_check_or_action(connection, run_name, run_kwargs)
             print('-RUN-> RESULT:  %s (uuid)' % str(run_result.get('uuid')))

--- a/foursight_core/buckets.py
+++ b/foursight_core/buckets.py
@@ -1,6 +1,8 @@
 import boto3
 import json
 
+from dcicutils.misc_utils import ignored
+
 
 class Buckets(object):
     """create and configure buckets for foursight"""
@@ -25,16 +27,23 @@ class Buckets(object):
     def env_bucket(self):
         return self.prefix + '-envs'
 
-    def ff_env(self, env):
-        return 'fourfront-%s' % env
+    @classmethod
+    def ff_env(cls, env):
+        return 'fourfront-%s' % env  # TODO: Should we use dcicutils.env_utils.full_env_name?
 
-    def ff_url(self, env):
+    @classmethod
+    def ff_url(cls, env):
+        ignored(env)
         # replace this with the correct url in the child class
-        return 'http://placeholder_url'  # e.g. 'https://cgap.hms.harvard.edu/'
+        # e.g. 'https://cgap.hms.harvard.edu/'
+        return 'http://placeholder_url'
 
-    def es_url(self, env):
+    @classmethod
+    def es_url(cls, env):
+        ignored(env)
         # replace this with the correct url in the child class
-        return 'https://placeholder_url'  # e.g. "https://search-cgap-testing-6-8-vo4mdkmkshvmyddc65ux7dtaou.us-east-1.es.amazonaws.com"
+        # e.g. "https://search-cgap-testing-6-8-vo4mdkmkshvmyddc65ux7dtaou.us-east-1.es.amazonaws.com"
+        return 'https://placeholder_url'
 
     def create_buckets(self):
         s3 = boto3.client('s3')

--- a/foursight_core/check_utils.py
+++ b/foursight_core/check_utils.py
@@ -94,53 +94,67 @@ class CheckHandler(object):
         for check_string in all_check_strings:
             mod_name, check_name = check_string.split('/')
             if check_name in found_checks:
-                raise BadCheckSetup('More than one check with name "%s" was found. See module "%s"' % (check_name,
-                                                                                                       mod_name))
+                raise BadCheckSetup(f'More than one check with name "{check_name}" was found. See module "{mod_name}"')
             found_checks[check_name] = mod_name
         for check_name in check_setup:
             if check_name not in found_checks:
-                raise BadCheckSetup('Check with name %s was in check_setup.json but does not have a proper check function defined.' % check_name)
+                raise BadCheckSetup(f'Check with name {check_name} was in check_setup.json'
+                                    f' but does not have a proper check function defined.')
             if not isinstance(check_setup[check_name], dict):
-                raise BadCheckSetup('Entry for "%s" in check_setup.json must be a dictionary.' % check_name)
+                raise BadCheckSetup(f'Entry for "{check_name}" in check_setup.json must be a dictionary.')
             # these fields are required
             if not {'title', 'group', 'schedule'} <= set(check_setup[check_name].keys()):
-                raise BadCheckSetup('Entry for "%s" in check_setup.json must have the required keys: "title", "group", and "schedule".' % check_name)
+                raise BadCheckSetup(f'Entry for "{check_name}" in check_setup.json must have'
+                                    f' the required keys: "title", "group", and "schedule".')
             # these fields must be strings
             for field in ['title', 'group']:
                 if not isinstance(check_setup[check_name][field], str):
-                    raise BadCheckSetup('Entry for "%s" in check_setup.json must have a string value for field "%s".' % (check_name, field))
+                    raise BadCheckSetup(f'Entry for "{check_name}" in check_setup.json'
+                                        f' must have a string value for field "{field}".')
             if not isinstance(check_setup[check_name]['schedule'], dict):
-                raise BadCheckSetup('Entry for "%s" in check_setup.json must have a dictionary value for field "schedule".' % check_name)
+                raise BadCheckSetup(f'Entry for "{check_name}" in check_setup.json'
+                                    f' must have a dictionary value for field "schedule".')
             # make sure a display is set up if there is no schedule
             if check_setup[check_name]['schedule'] == {} and check_setup[check_name].get('display') is None:
-                raise BadCheckSetup('Entry for "%s" in check_setup.json must have a list of "display" environments if it lacks a schedule.' % check_name)
+                raise BadCheckSetup(f'Entry for "{check_name}" in check_setup.json'
+                                    f' must have a list of "display" environments if it lacks a schedule.')
             # now validate and add defaults to the schedule
             for sched_name, schedule in check_setup[check_name]['schedule'].items():
                 if not isinstance(schedule, dict):
-                    raise BadCheckSetup('Schedule "%s" for "%s" in check_setup.json must have a dictionary value.' % (sched_name, check_name))
+                    raise BadCheckSetup(f'Schedule "{sched_name}" for "{check_name}" in check_setup.json'
+                                        f' must have a dictionary value.')
                 for env_name, env_detail in schedule.items():
-                    if not env_name in all_environments:
-                        raise BadCheckSetup('Environment "%s" in schedule "%s" for "%s" in check_setup.json is not an existing'
-                                            ' environment. Create with PUT to /environments endpoint.'
-                                            % (env_name, sched_name, check_name))
+                    if env_name not in all_environments:
+                        raise BadCheckSetup(f'Environment "{env_name}" in schedule "{sched_name}" for "{check_name}"'
+                                            f' in check_setup.json is not an existing'
+                                            f' environment. Create with PUT to /environments endpoint.')
                     if not isinstance(env_detail, dict):
-                        raise BadCheckSetup('Environment "%s" in schedule "%s" for "%s" in check_setup.json must have a dictionary value.' % (env_name, sched_name, check_name))
+                        raise BadCheckSetup(f'Environment "{env_name}" in schedule "{sched_name}"'
+                                            f' for "{check_name}" in check_setup.json'
+                                            f' must have a dictionary value.')
                     # default values
-                    if not 'kwargs' in env_detail:
+                    if 'kwargs' not in env_detail:
                         env_detail['kwargs'] = {'primary': True}
                     else:
                         if not isinstance(env_detail['kwargs'], dict):
-                            raise BadCheckSetup('Environment "%s" in schedule "%s" for "%s" in check_setup.json must have a dictionary value for "kwargs".' % (env_name, sched_name, check_name))
-                    if not 'dependencies' in env_detail:
+                            raise BadCheckSetup(f'Environment "{env_name}" in schedule "{sched_name}"'
+                                                f' for "{check_name}" in check_setup.json'
+                                                f' must have a dictionary value for "kwargs".')
+                    if 'dependencies' not in env_detail:
                         env_detail['dependencies'] = []
                     else:
                         if not isinstance(env_detail['dependencies'], list):
-                            raise BadCheckSetup('Environment "%s" in schedule "%s" for "%s" in check_setup.json must have a list value for "dependencies".' % (env_name, sched_name, check_name))
+                            raise BadCheckSetup(f'Environment "{env_name}" in schedule "{sched_name}"'
+                                                f' for "{check_name}" in check_setup.json'
+                                                f' must have a list value for "dependencies".')
                         else:
                             # confirm all dependencies are legitimate check names
                             for dep_id in env_detail['dependencies']:
                                 if dep_id not in self.get_checks_within_schedule(sched_name):
-                                    raise BadCheckSetup('Environment "%s" in schedule "%s" for "%s" in check_setup.json must has a dependency "%s" that is not a valid check name that shares the same schedule.' % (env_name, sched_name, check_name, dep_id))
+                                    raise BadCheckSetup(f'Environment "{env_name}" in schedule "{sched_name}"'
+                                                        f' for "{check_name}" in check_setup.json'
+                                                        f' must has a dependency "{dep_id}" that'
+                                                        f' is not a valid check name that shares the same schedule.')
 
             # lastly, add the check module information to each check in the setup
             check_setup[check_name]['module'] = found_checks[check_name]
@@ -197,7 +211,7 @@ class CheckHandler(object):
         """
         check_schedule = {}
         for check_name, detail in self.CHECK_SETUP.items():
-            if not schedule_name in detail['schedule']:
+            if schedule_name not in detail['schedule']:
                 continue
             # skip the check if conditions provided and any are not met
             if conditions and isinstance(conditions, list):
@@ -214,7 +228,7 @@ class CheckHandler(object):
         # although not strictly necessary right now, this is a precaution
         return copy.deepcopy(check_schedule)
 
-    def get_check_results(self, connection, checks=[], use_latest=False):
+    def get_check_results(self, connection, checks=None, use_latest=False):
         """
         Initialize check results for each desired check and get results stored
         in s3, sorted by status and then alphabetically by title.
@@ -223,6 +237,7 @@ class CheckHandler(object):
         By default, gets the 'primary' results. If use_latest is True, get the
         'latest' results instead.
         """
+        checks = checks or []
         check_results = []
         if not checks:
             checks = [check_str.split('/')[1] for check_str in self.get_check_strings()]
@@ -237,7 +252,7 @@ class CheckHandler(object):
                 # checks with no records will return None. Skip IGNORE checks
                 if found and found.get('status') != 'IGNORE':
                     check_results.append(found)
-                if not found: # add placeholder check
+                if not found:  # add placeholder check
                     check_results.append(CheckSchema().create_placeholder_check(check_name))
 
         else:
@@ -251,7 +266,9 @@ class CheckHandler(object):
         stat_order = ['ERROR', 'FAIL', 'WARN', 'PASS']
         return sorted(
             check_results,
-            key=lambda v: (stat_order.index(v['status']) if v['status'] in stat_order else 9, self.get_check_title_from_setup(v['name']).lower())
+            key=lambda v: (stat_order.index(v['status'])
+                           if v['status'] in stat_order
+                           else 9, self.get_check_title_from_setup(v['name']).lower())
         )
 
     def get_grouped_check_results(self, connection):
@@ -313,7 +330,7 @@ class CheckHandler(object):
         except ModuleNotFoundError:
             return ' '.join(['ERROR. Check module is not valid.', error_str])
         except Exception as e:
-            raise(e)
+            raise e
         check_method = check_mod.__dict__.get(check_name)
         if not check_method:
             return ' '.join(['ERROR. Check name is not valid.', error_str])
@@ -334,7 +351,7 @@ class CheckHandler(object):
         if not check_str:
             check_str = self.get_action_strings(check)
             is_action = True
-        if not check_str: # not a check or an action. abort
+        if not check_str:  # not a check or an action. abort
             return None
         return self.ActionResult(connection, check) if is_action else self.CheckResult(connection, check)
 

--- a/foursight_core/checks/__init__.py
+++ b/foursight_core/checks/__init__.py
@@ -3,4 +3,6 @@ import glob
 
 # Add all files in this directory to the package
 modules = glob.glob(dirname(__file__)+"/*.py")
-__all__ = [ basename(f)[:-3] for f in modules if isfile(f) and not f.endswith('__init__.py')]
+__all__ = [basename(f)[:-3]
+           for f in modules
+           if isfile(f) and not f.endswith('__init__.py')]

--- a/foursight_core/checks/helpers/confchecks.py
+++ b/foursight_core/checks/helpers/confchecks.py
@@ -1,7 +1,7 @@
 # Create a new confchecks.py for a new project (e.g. foursight-cgap)
 from ...decorators import Decorators
 
-# replace placeholder_prefix with an actual foursight_prefix 
+# replace placeholder_prefix with an actual foursight_prefix
 deco = Decorators('placeholder_prefix')
 CheckResult = deco.CheckResult
 ActionResult = deco.ActionResult

--- a/foursight_core/checks/helpers/sys_utils.py
+++ b/foursight_core/checks/helpers/sys_utils.py
@@ -52,17 +52,17 @@ def parse_datetime_to_utc(time_str, manual_format=None):
     else:  # automatic parsing
         if len(time_str) > 26 and time_str[26] in ['+', '-']:
             try:
-                timeobj = datetime.strptime(time_str[:26],'%Y-%m-%dT%H:%M:%S.%f')
+                timeobj = datetime.strptime(time_str[:26], '%Y-%m-%dT%H:%M:%S.%f')
             except ValueError:
                 return None
-            if time_str[26]=='+':
+            if time_str[26] == '+':
                 timeobj -= timedelta(hours=int(time_str[27:29]), minutes=int(time_str[30:]))
-            elif time_str[26]=='-':
+            elif time_str[26] == '-':
                 timeobj += timedelta(hours=int(time_str[27:29]), minutes=int(time_str[30:]))
         elif len(time_str) == 26 and '+' not in time_str[-6:] and '-' not in time_str[-6:]:
             # nothing known about tz, just parse it without tz in this cause
             try:
-                timeobj = datetime.strptime(time_str[0:26],'%Y-%m-%dT%H:%M:%S.%f')
+                timeobj = datetime.strptime(time_str[0:26], '%Y-%m-%dT%H:%M:%S.%f')
             except ValueError:
                 return None
         else:

--- a/foursight_core/checks/test_checks.py
+++ b/foursight_core/checks/test_checks.py
@@ -5,7 +5,13 @@ import time
 # rather than importing check_function, action_function, CheckResult, ActionResult
 # individually - they're now part of class Decorators in foursight-core::decorators
 # that requires initialization with foursight prefix.
-from .helpers.confchecks import *
+
+from dcicutils.misc_utils import ignored
+# from .helpers.confchecks import *
+from .helpers.confchecks import (
+    check_function, CheckResult,
+    action_function, ActionResult,
+)
 
 
 def test_function_unused():
@@ -15,12 +21,14 @@ def test_function_unused():
 # meant to raise an error on execution by dividing by 0
 @check_function()
 def test_check_error(connection, **kwargs):
+    ignored(connection, kwargs)
     bad_op = 10 * 1/0
     return bad_op
 
 
 @action_function()
 def test_action_error(connection, **kwargs):
+    ignored(connection, kwargs)
     bad_op = 10 * 1/0
     return bad_op
 
@@ -28,6 +36,7 @@ def test_action_error(connection, **kwargs):
 # silly check that stores random numbers in a list
 @check_function()
 def test_random_nums(connection, **kwargs):
+    ignored(kwargs)
     check = CheckResult(connection, 'test_random_nums')
     check.status = 'IGNORE'
     check.action = 'add_random_test_nums'
@@ -45,6 +54,7 @@ def test_random_nums(connection, **kwargs):
 # same as above
 @check_function()
 def test_random_nums_2(connection, **kwargs):
+    ignored(kwargs)
     check = CheckResult(connection, 'test_random_nums_2')
     check.status = 'IGNORE'
     output = []

--- a/foursight_core/deploy.py
+++ b/foursight_core/deploy.py
@@ -8,7 +8,7 @@ import argparse
 import json
 import subprocess
 
-from dcicutils.misc_utils import as_seconds
+from dcicutils.misc_utils import as_seconds, ignored
 
 
 class Deploy(object):
@@ -54,6 +54,7 @@ class Deploy(object):
                      security_group_ids=None, subnet_ids=None, check_runner=None, rds_name=None,
                      lambda_timeout=DEFAULT_LAMBDA_TIMEOUT):
         """ Builds the chalice config json file. See: https://aws.github.io/chalice/topics/configfile"""
+        ignored(stage)
         if trial_creds:
             # key to decrypt access key
             s3_enc_secret = trial_creds['S3_ENCRYPT_KEY']

--- a/foursight_core/environment.py
+++ b/foursight_core/environment.py
@@ -1,5 +1,3 @@
-import os
-import json
 from .s3_connection import S3Connection
 
 
@@ -61,6 +59,7 @@ class Environment(object):
         Returns a dictionary keyed by environment name with value of a sub-dict
         with the fields needed to initiate a connection.
 
+        :param stage: the relevant chalice stage
         :param env: allows you to specify a single env to be initialized
         :param envs: allows you to specify multiple envs to be initialized
         """
@@ -69,7 +68,7 @@ class Environment(object):
         else:
             try:
                 env_keys = self.get_selected_environment_names(env)
-            except:
+            except Exception:
                 return {}  # provided env is not in s3
 
         environments = {}

--- a/foursight_core/package.py
+++ b/foursight_core/package.py
@@ -1,7 +1,6 @@
 import argparse
-import subprocess
+
 from foursight_core.deploy import Deploy
-from sys import stdout
 from os.path import dirname
 
 

--- a/foursight_core/run_result.py
+++ b/foursight_core/run_result.py
@@ -112,13 +112,14 @@ class RunResult(object):
                     check_time = datetime.datetime.strptime(time_str, "%Y-%m-%dT%H:%M:%S.%f")
                 except ValueError:
                     continue
-                check_time = check_time.replace(tzinfo=tz.tzutc()) # always UTC
+                check_time = check_time.replace(tzinfo=tz.tzutc())  # always UTC
                 check_tuples.append((check, check_time))
         if override_date:
             desired_time = override_date.replace(tzinfo=tz.tzutc())
         else:
-            desired_time = (datetime.datetime.utcnow() -
-                datetime.timedelta(hours=diff_hours, minutes=diff_mins)).replace(tzinfo=tz.tzutc())
+            desired_time = (
+                    datetime.datetime.utcnow() - datetime.timedelta(hours=diff_hours, minutes=diff_mins)
+            ).replace(tzinfo=tz.tzutc())
         best_match = get_closest(check_tuples, desired_time)
         # ensure that the does not have status 'ERROR'
         match_res = None
@@ -234,6 +235,7 @@ class RunResult(object):
         """
         if self.es:
             history = self.connections['es'].get_result_history(self.name, start, limit)
+
             def wrapper(obj):
                 filename = obj.get('_id')
                 if filename is None:
@@ -296,11 +298,11 @@ class RunResult(object):
         return formatted
 
     def filename_to_datetime(self, key):
-        '''
+        """
         Utility function.
         Key might look like `sync_google_analytics_data/2018-10-15T19:08:32.734656.json`
         We presume that timezone info is not important to allow us to use strptime.
-        '''
+        """
         prefixlen = len(self.name) + 1
         keydatestr = key[prefixlen:-5]  # Remove prefix and .json from key.
         return datetime.datetime.strptime(keydatestr, '%Y-%m-%dT%H:%M:%S.%f')
@@ -333,7 +335,7 @@ class CheckResult(RunResult):
             stamp_res = self.get_object(ts_key)
             if stamp_res:
                 for key, val in stamp_res.items():
-                    if key not in ['uuid', 'kwargs']: # dont copy these
+                    if key not in ['uuid', 'kwargs']:  # dont copy these
                         setattr(self, key, val)
                 return
         # summary will be displayed next to title when set
@@ -349,7 +351,7 @@ class CheckResult(RunResult):
         self.ff_link = ''
         # self.action_name is the function name of the action to link to check
         self.action = ''
-        self.allow_action = False # by default do not allow the action to be run
+        self.allow_action = False  # by default do not allow the action to be run
         self.action_message = 'Are you sure you want to run this action?'
 
     def format_result(self, uuid):
@@ -385,9 +387,11 @@ class CheckResult(RunResult):
         store_method = getattr(self, 'store_result', None)
         if not callable(store_method):
             error_msg.append('Do not overwrite the store_result method.')
+
         def _validate(attr, t):
             if not isinstance(attr, t):
                 error_msg.append('%s is not of type %s' % (str(attr), str(t)))
+
         _validate(self.name, str)
         _validate(self.summary, str)
         _validate(self.description, str)
@@ -456,9 +460,11 @@ class ActionResult(RunResult):
         store_method = getattr(self, 'store_result', None)
         if not callable(store_method):
             error_msg.append('Do not overwrite the store_result method.')
+
         def _validate(attr, t):
             if not isinstance(attr, t):
                 error_msg.append('%s is not of type %s' % (str(attr), str(t)))
+
         _validate(self.status, str)
         _validate(self.description, str)
         _validate(self.name, str)
@@ -499,7 +505,8 @@ class ActionResult(RunResult):
         return check.get_result_by_uuid(called_by)
 
 
-### Utility functions for check_result
+# ===== Utility functions for check_result =====
+
 def get_closest(items, pivot):
     """
     Return the item in the list of items closest to the given pivot.

--- a/foursight_core/s3_connection.py
+++ b/foursight_core/s3_connection.py
@@ -5,6 +5,8 @@ import boto3
 import datetime
 import logging
 
+from dcicutils.misc_utils import full_class_name
+
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
@@ -42,10 +44,8 @@ class S3Connection(AbstractConnection):
             return key, value
 
     def get_all_objects(self):
-        # In fact, the parent does not implement this and will raise NotImplementedError,
-        # but adding this definition reminds us that that we didn't accidentally not implement this.
-        # (We didn't, did we?)  -kmp 7-Jun-2022
-        return super().get_all_objects()
+        raise NotImplementedError(f"The get_all_objects operation is not allowed"
+                                  f" for objects of type {full_class_name(self)}.")
 
     def get_object(self, key):
         # return found bucket content or None on an error

--- a/foursight_core/sqs_utils.py
+++ b/foursight_core/sqs_utils.py
@@ -1,6 +1,8 @@
-from datetime import datetime
 import boto3
 import json
+
+from datetime import datetime
+from dcicutils.misc_utils import ignored
 from .stage import Stage
 
 
@@ -26,7 +28,7 @@ class SQS(object):
                 InvocationType='Event',
                 Payload=json.dumps(runner_input)
             )
-        except:
+        except Exception:
             response = client.invoke(
                 FunctionName=self.stage.get_runner_name(),
                 Payload=json.dumps(runner_input)
@@ -95,7 +97,7 @@ class SQS(object):
         sqs = boto3.resource('sqs')
         try:
             queue = sqs.get_queue_by_name(QueueName=queue_name)
-        except:
+        except Exception:
             queue = sqs.create_queue(
                 QueueName=queue_name,
                 Attributes={
@@ -129,6 +131,7 @@ class SQS(object):
         proc_vals = [[environ, uuid] + val for val in check_vals]
         for val in proc_vals:
             response = queue.send_message(MessageBody=json.dumps(val))
+            ignored(response)
         return uuid
 
     @classmethod
@@ -149,6 +152,6 @@ class SQS(object):
                     'ApproximateNumberOfMessagesNotVisible'
                 ]
             )
-        except:
+        except Exception:
             return backup
         return result.get('Attributes', backup)

--- a/poetry.lock
+++ b/poetry.lock
@@ -258,6 +258,20 @@ six = "*"
 develop = ["mock", "pytest (>=3.0.0)", "pytest-cov", "pytz", "coverage (<5.0.0)", "sphinx", "sphinx-rtd-theme"]
 
 [[package]]
+name = "flake8"
+version = "4.0.1"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+importlib-metadata = {version = "<4.3", markers = "python_version < \"3.8\""}
+mccabe = ">=0.6.0,<0.7.0"
+pycodestyle = ">=2.8.0,<2.9.0"
+pyflakes = ">=2.4.0,<2.5.0"
+
+[[package]]
 name = "flaky"
 version = "3.6.1"
 description = "Plugin for nose or pytest that automatically reruns flaky tests."
@@ -413,7 +427,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.8.3"
+version = "4.2.0"
 description = "Read metadata from Python packages"
 category = "dev"
 optional = false
@@ -425,8 +439,7 @@ zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-perf = ["ipython"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "inquirer"
@@ -481,6 +494,14 @@ description = "Safely add untrusted strings to HTML/XML markup."
 category = "main"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+
+[[package]]
+name = "mccabe"
+version = "0.6.1"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "more-itertools"
@@ -557,6 +578,22 @@ python-versions = "*"
 
 [package.dependencies]
 pyasn1 = ">=0.4.6,<0.5.0"
+
+[[package]]
+name = "pycodestyle"
+version = "2.8.0"
+description = "Python style guide checker"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "pyflakes"
+version = "2.4.0"
+description = "passive checker of Python programs"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pyjwt"
@@ -899,7 +936,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.1,<3.8"
-content-hash = "b4bf4abbb24323671720eced33e2dcb42f4925754804fd8e5a7e5c03a3ae98e3"
+content-hash = "65c41c9833db52a4065d933874e5f1d6dd4768af833db099703d8d16a3994543"
 
 [metadata.files]
 ansicon = [
@@ -1027,6 +1064,10 @@ elasticsearch-dsl = [
     {file = "elasticsearch-dsl-6.4.0.tar.gz", hash = "sha256:26416f4dd46ceca43d62ef74970d9de4bdd6f4b0f163316f0b432c9e61a08bec"},
     {file = "elasticsearch_dsl-6.4.0-py2.py3-none-any.whl", hash = "sha256:f60aea7fd756ac1fbe7ce114bbf4949aefbf495dfe8896640e787c67344f12f6"},
 ]
+flake8 = [
+    {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
+    {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
+]
 flaky = [
     {file = "flaky-3.6.1-py2.py3-none-any.whl", hash = "sha256:5471615b32b0f8086573de924475b1f0d31e0e8655a089eb9c38a0fbff3f11aa"},
     {file = "flaky-3.6.1.tar.gz", hash = "sha256:8cd5455bb00c677f787da424eaf8c4a58a922d0e97126d3085db5b279a98b698"},
@@ -1075,8 +1116,8 @@ idna = [
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.8.3-py3-none-any.whl", hash = "sha256:65a9576a5b2d58ca44d133c42a241905cc45e34d2c06fd5ba2bafa221e5d7b5e"},
-    {file = "importlib_metadata-4.8.3.tar.gz", hash = "sha256:766abffff765960fcc18003801f7044eb6755ffae4521c8e8ce8e83b9c9b0668"},
+    {file = "importlib_metadata-4.2.0-py3-none-any.whl", hash = "sha256:057e92c15bc8d9e8109738a48db0ccb31b4d9d5cfbee5a8670879a30be66304b"},
+    {file = "importlib_metadata-4.2.0.tar.gz", hash = "sha256:b7e52a1f8dec14a75ea73e0891f3060099ca1d8e6a462a4dff11c3e119ea1b31"},
 ]
 inquirer = [
     {file = "inquirer-2.8.0-py2.py3-none-any.whl", hash = "sha256:237c14a68bcf0b2950899aa11bcc342de613e9389e4bf6fcd2ef97fcb3b1590a"},
@@ -1147,6 +1188,10 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp39-cp39-win32.whl", hash = "sha256:22c178a091fc6630d0d045bdb5992d2dfe14e3259760e713c490da5323866c39"},
     {file = "MarkupSafe-1.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:b7d644ddb4dbd407d31ffb699f1d140bc35478da613b441c582aeb7c43838dd8"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
+]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 more-itertools = [
     {file = "more-itertools-8.12.0.tar.gz", hash = "sha256:7dc6ad46f05f545f900dd59e8dfb4e84a4827b97b3cfecb175ea0c7d247f6064"},
@@ -1225,6 +1270,14 @@ pyasn1-modules = [
     {file = "pyasn1_modules-0.2.8-py3.5.egg", hash = "sha256:426edb7a5e8879f1ec54a1864f16b882c2837bfd06eee62f2c982315ee2473ed"},
     {file = "pyasn1_modules-0.2.8-py3.6.egg", hash = "sha256:cbac4bc38d117f2a49aeedec4407d23e8866ea4ac27ff2cf7fb3e5b570df19e0"},
     {file = "pyasn1_modules-0.2.8-py3.7.egg", hash = "sha256:c29a5e5cc7a3f05926aff34e097e84f8589cd790ce0ed41b67aed6857b26aafd"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
+    {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
+]
+pyflakes = [
+    {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
+    {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
 ]
 pyjwt = [
     {file = "PyJWT-1.5.3-py2.py3-none-any.whl", hash = "sha256:a4e5f1441e3ca7b382fd0c0b416777ced1f97c64ef0c33bfa39daf38505cfd2f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight_core"
-version = "0.6.0"
+version = "0.6.1"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ pytz = "^2020.1"
 
 [tool.poetry.dev-dependencies]
 chalice = "^1.21.4"
+flake8 = ">=3.9.2"
 pytest = "5.1.2"
 pytest-cov = "2.7.1"
 flaky = "3.6.1"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,9 +3,9 @@ from foursight_core.checks.helpers import sys_utils
 
 
 class TestHelpers():
-    timestr_1 = '2017-04-09T17:34:53.423589+00:00' # UTC
-    timestr_2 = '2017-04-09T17:34:53.423589+05:00' # 5 hours ahead of UTC
-    timestr_3 = '2017-04-09T17:34:53.423589-05:00' # 5 hours behind of UTC
+    timestr_1 = '2017-04-09T17:34:53.423589+00:00'  # UTC
+    timestr_2 = '2017-04-09T17:34:53.423589+05:00'  # 5 hours ahead of UTC
+    timestr_3 = '2017-04-09T17:34:53.423589-05:00'  # 5 hours behind of UTC
     timestr_4 = '2017-04-09T17:34:53.423589'
     timestr_5 = '2017-04-09T17:34:53'
     timestr_bad_1 = '2017-04-0589+00:00'


### PR DESCRIPTION
I was making some other changes to `foursight-core`, and I didn't want cosmetic changes to get lost among the more substantive ones, so I'm factoring this out as a separate PR. With this PR, `flake8` will run cleanly; e.g., try `make lint`.

* Add flake8 to pyproject.toml, bump patch version.
* A `make lint` target that runs flake8.
* Bring `CHANGELOG.rst` up-to-date with recent changes that haven't been getting updated.
* A lot of cosmetic PEP8 changes.
  * The usual whitespace nonsense that flake8 goes crazy about.
  * A number of changes to use f-strings, since in many cases these were PEP8 line overruns and I was editing the line in question anyway.
  * A bunch of ignored arguments that I made explicitly use `ignored(...)`
  * Eliminate an `import *` in `checks/test_checks.py`
* A few changes of substance for things that PEP8 found that were not quite right.
  * Some raw `except:` that should have been `except Exception:`
  * Some situations where local variables were defined but not used.
  * Some situations where variables might not have been properly initialized, but especially in `get_object` in `s3_connection.py`, where I had to introduce a second level of `try` in order to make the variables work out.
  * A `get_all_objects` method (in `s3_connection.py` that was not implemented from an abstract class. It seems to be implemented only in `es_connection.py`.
