### PR TITLE
Make pyproject.toml and poetry.lock consistent.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ foursight-core
 Change Log
 ----------
 
+1.0.1
+=====
+
+* Make pyproject.toml and poetry.lock consistent.
+
 
 1.0.0
 =====
@@ -29,7 +34,6 @@ Change Log
 =====
 
 Fix Environment.is_valid_environment_name to return true of various environments.
-
 
 
 0.7.4

--- a/foursight_core/app_utils.py
+++ b/foursight_core/app_utils.py
@@ -15,7 +15,7 @@ from itertools import chain
 from dateutil import tz
 from dcicutils import ff_utils
 from dcicutils.lang_utils import disjoined_list
-from dcicutils.obfuscation_utils import obfuscate_dict
+# from dcicutils.obfuscation_utils import obfuscate_dict
 from typing import Optional
 from .identity import apply_identity_globally
 from .s3_connection import S3Connection

--- a/foursight_core/deploy.py
+++ b/foursight_core/deploy.py
@@ -64,7 +64,12 @@ class Deploy(object):
         """ Builds the chalice config json file. See: https://aws.github.io/chalice/topics/configfile"""
         # dmichaels/2022-07-22/C4-826:
         # Removed value from the Foursight CloudFormation template; get from GAC/etc at runtime.
-        ignored(stage)
+        # TODO: Is it in fact correct that we are not using rds_name here? The changelog for 1.0.0 doesn't mention it,
+        #       and should be retroactively modified to explain any changes in environment variable use due to the
+        #       1.0.0 change so that users can better adapt to this upgrade. (I noticed that one or more FF
+        #       environments were missing this env variable and was searching all over for clues about why
+        #       that might be.) -kmp 19-Aug-2022
+        ignored(stage, rds_name)
         if trial_creds:
             # key to decrypt access key
             # s3_enc_secret = trial_creds['S3_ENCRYPT_KEY']
@@ -173,6 +178,9 @@ class Deploy(object):
             environment variables, a list of security group ids, and a list of subnet ids. Finally, packages as a
             Cloudformation template."""
 
+        # TODO: This passes rds_name through, but build_config is no longer using it. Is that correct?
+        #       Should this be just marking that arg ignored or just not receiving such an arg?
+        #       Something is weird in that data flow chain. -kmp 19-Aug-2022
         # For compatibility during transition, we allow these argument to be passed in lieu of args.
         if merge_template is None:
             merge_template = args.merge_template
@@ -187,7 +195,8 @@ class Deploy(object):
             if trial_creds and security_ids and subnet_ids and check_runner:
                 # dmichaels/2022-07-22/C4-826:
                 # Added identity arg for the Foursight CloudFormation template.
-                cls.build_config(stage, identity=identity, stack_name=stack_name, trial_creds=trial_creds, trial_global_env_bucket=True,
+                cls.build_config(stage, identity=identity, stack_name=stack_name, trial_creds=trial_creds,
+                                 trial_global_env_bucket=True,
                                  global_env_bucket=global_env_bucket, lambda_timeout=lambda_timeout,
                                  security_group_ids=security_ids, subnet_ids=subnet_ids, check_runner=check_runner,
                                  rds_name=rds_name)

--- a/poetry.lock
+++ b/poetry.lock
@@ -178,7 +178,7 @@ toml = ["tomli"]
 
 [[package]]
 name = "dcicutils"
-version = "4.0.1.1b0"
+version = "4.4.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 category = "main"
 optional = false
@@ -374,10 +374,10 @@ rsa = {version = ">=3.1.4,<5", markers = "python_version >= \"3.6\""}
 six = ">=1.9.0"
 
 [package.extras]
-aiohttp = ["requests (>=2.20.0,<3.0.0dev)", "aiohttp (>=3.6.2,<4.0.0dev)"]
-enterprise_cert = ["cryptography (==36.0.2)", "pyopenssl (==22.0.0)"]
-pyopenssl = ["pyopenssl (>=20.0.0)"]
 reauth = ["pyu2f (>=0.1.5)"]
+pyopenssl = ["pyopenssl (>=20.0.0)"]
+enterprise_cert = ["pyopenssl (==22.0.0)", "cryptography (==36.0.2)"]
+aiohttp = ["aiohttp (>=3.6.2,<4.0.0dev)", "requests (>=2.20.0,<3.0.0dev)"]
 
 [[package]]
 name = "google-auth-httplib2"
@@ -928,7 +928,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.9"
-content-hash = "0717bb3f78c7825d4f577e43625fc0fa07711f003cb62a11bed6ab8ff7aa3fdb"
+content-hash = "1f6e6559d9e809778dcedd357f8dc1fed9eb62fe71f4015c3d053c38a0f7df99"
 
 [metadata.files]
 ansicon = [
@@ -1030,8 +1030,8 @@ coverage = [
     {file = "coverage-6.4.2.tar.gz", hash = "sha256:6c3ccfe89c36f3e5b9837b9ee507472310164f352c9fe332120b764c9d60adbe"},
 ]
 dcicutils = [
-    {file = "dcicutils-4.0.1.1b0-py3-none-any.whl", hash = "sha256:35889f5e2d15d3f6e94988c05a5344e6479699c72d1d9048e55b2c8cac00f4d3"},
-    {file = "dcicutils-4.0.1.1b0.tar.gz", hash = "sha256:07830dc671c07647c8857b2d8a58d4f07cc36b5d33f5de33f8686011a81edf78"},
+    {file = "dcicutils-4.4.0-py3-none-any.whl", hash = "sha256:995a7b0fb68cc2fd3cf886b56e48d9699346d14a212f632f22588b2e1662811d"},
+    {file = "dcicutils-4.4.0.tar.gz", hash = "sha256:bc198aceb9894d9809d12703374cd1e64a10f55ed84fba5555195c6b450c7e9c"},
 ]
 decorator = [
     {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight-core"
-version = "1.0.0"
+version = "1.0.1"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.7,<3.9"
-dcicutils = "^4.0.2"
+dcicutils = "^4.4.0"
 click = "^7.1.2"
 PyJWT = "1.5.3"
 Jinja2 = "2.10.1"


### PR DESCRIPTION
* pyproject.toml and poetry.lock are out of sync on master for foursight-core, so did a `poetry update dcicutils` to get a new `poetry.lock`. This pulled in `dcicutils 4.4.0`, so I updated `pyproject.toml` to require that version, since it's harmless and it speeds locking.
* Made some PEP8 updates so that `make lint` would pass.  Noticed some issues that might want to be repaired later and made comments about them, but I think the fixes should not go in this PR, since the main purpose of this PR is to get `poetry.lock` consistent on master and that should be done soon.
* Updated CHANGELOG and bumped version.