### PR TITLE
Common Redis auth namespace.

### DIFF
--- a/foursight_core/app_utils.py
+++ b/foursight_core/app_utils.py
@@ -44,6 +44,7 @@ from .deploy import Deploy
 from .environment import Environment
 from .fs_connection import FSConnection
 from .s3_connection import S3Connection
+from .react.api.auth import Auth
 from .react.api.react_api import ReactApi
 from .routes import Routes
 from .route_prefixes import CHALICE_LOCAL
@@ -474,7 +475,7 @@ class AppUtilsCore(ReactApi, Routes):
         redis_handler = conn.get_redis_base()
         if redis_handler:
             redis_session_token = RedisSessionToken(
-                namespace=env, jwt=id_token
+                namespace=Auth.get_redis_namespace(env), jwt=id_token
             )
             redis_session_token.store_session_token(redis_handler=redis_handler)
             # overwrite id_token in this case to be the session token
@@ -525,7 +526,7 @@ class AppUtilsCore(ReactApi, Routes):
             if redis_handler:
                 redis_session_token = RedisSessionToken.from_redis(
                     redis_handler=redis_handler,
-                    namespace=canonical_env_name,
+                    namespace=Auth.get_redis_namespace(canonical_env_name),
                     token=jwt_token  # this is NOT JWT but the session token itself
                 )
                 if (not redis_session_token or

--- a/foursight_core/react/api/react_api.py
+++ b/foursight_core/react/api/react_api.py
@@ -19,6 +19,7 @@ from dcicutils.obfuscation_utils import obfuscate_dict
 from dcicutils.redis_tools import RedisSessionToken, SESSION_TOKEN_COOKIE
 from ...app import app
 from .auth import AUTH_TOKEN_COOKIE
+from .auth import Auth
 from .aws_network import (
     aws_get_network, aws_get_security_groups,
     aws_get_security_group_rules, aws_get_subnets, aws_get_vpcs, aws_network_cache_clear
@@ -252,7 +253,7 @@ class ReactApi(ReactApiBase, ReactRoutes):
         if redis_handler:
             redis_session_token = RedisSessionToken.from_redis(
                 redis_handler=redis_handler,
-                namespace=env,
+                namespace=Auth.get_redis_namespace(env),
                 token=read_cookie(request, SESSION_TOKEN_COOKIE)
             )
             if redis_session_token:

--- a/foursight_core/react/api/react_api_base.py
+++ b/foursight_core/react/api/react_api_base.py
@@ -176,7 +176,7 @@ class ReactApiBase:
         redis_handler = self._auth.get_redis_handler()
         if redis_handler:
             redis_session_token = RedisSessionToken(
-                namespace=env, jwt=jwt
+                namespace=Auth.get_redis_namespace(env), jwt=jwt
             )
             redis_session_token.store_session_token(redis_handler=redis_handler)
             c4_st_cookie = create_set_cookie_string(request, name=SESSION_TOKEN_COOKIE,


### PR DESCRIPTION
Changed namespace for Redis auth from per-environment (e.g. fourfront-mastertest:session:xtyw1JSQb9Nw2ZRaYGs16VXjwnLt35UmYBhlDS5utS8) to just static per-foursight (e.g. foursight:session:SEgon871MFPejH0LC565SWxtCiMlgGXNd9lsBa8EFmI) so that we can change environments (via Foursight UI dropdown), as it previously worked.