### PR TITLE
fix: update git Lambda layer to git-lambda2:8 to remediate CVE-2022-2…

### DIFF
--- a/.chalice/deployed.json
+++ b/.chalice/deployed.json
@@ -26,7 +26,7 @@
       "api_gateway_stage": "api",
       "region": "us-east-1",
       "layers": [
-        "arn:aws:lambda:us-east-1:553035198032:layer:git:11"
+        "arn:aws:lambda:us-east-1:553035198032:layer:git-lambda2:8"
       ]
     },
     "dev": {
@@ -56,7 +56,7 @@
       "api_gateway_stage": "api",
       "region": "us-east-1",
       "layers": [
-        "arn:aws:lambda:us-east-1:553035198032:layer:git:11"
+        "arn:aws:lambda:us-east-1:553035198032:layer:git-lambda2:8"
       ]
     }
 }

--- a/foursight_core/deploy.py
+++ b/foursight_core/deploy.py
@@ -71,7 +71,7 @@ class Deploy(object):
       "version": "2.0",
       "app_name": "foursight-cgap",
       "layers": [
-          "arn:aws:lambda:us-east-1:553035198032:layer:git:11"  # required for Deployment Checks - Will 5/20/2020
+          "arn:aws:lambda:us-east-1:553035198032:layer:git-lambda2:8"  # required for Deployment Checks - Will 5/20/2020
       ]
     }
 


### PR DESCRIPTION
Updates the Git Lambda layer ARN from git:11 to git-lambda2:8 (lambci) across affected Lambda functions to remediate three known Git vulnerabilities.
Old ARN:
arn:aws:lambda:us-east-1:553035198032:layer:git:11
New ARN:
arn:aws:lambda:us-east-1:553035198032:layer:git-lambda2:8
CVEs Addressed

CVE-2022-24975 
CVE-2023-23946
CVE-2021-40330

No application code changes. Layer swap only. The git-lambda2 layer is compatible with Python 3.10.